### PR TITLE
Improve vendoring of some gems

### DIFF
--- a/lib/automatiek/gem.rb
+++ b/lib/automatiek/gem.rb
@@ -44,8 +44,10 @@ module Automatiek
     end
 
     def require_entrypoint
-      gem_name.tr("-", "/")
+      @require_entrypoint ||= gem_name.tr("-", "/")
     end
+
+    attr_writer :require_entrypoint
 
     def namespace_files
       require_target = vendor_lib.sub(%r{^(.+?/)?lib/}, "") << "/lib"

--- a/lib/automatiek/gem.rb
+++ b/lib/automatiek/gem.rb
@@ -43,11 +43,15 @@ module Automatiek
       Dir.glob("#{vendor_lib}/**/*.rb")
     end
 
+    def require_entrypoint
+      gem_name.tr("-", "/")
+    end
+
     def namespace_files
       require_target = vendor_lib.sub(%r{^(.+?/)?lib/}, "") << "/lib"
       process_files(namespace, "#{prefix}::#{namespace}")
-      process_files(/require (["'])#{Regexp.escape gem_name}/, "require \\1#{require_target}/#{gem_name}")
-      process_files(/(autoload\s+[:\w]+,\s+["'])(#{Regexp.escape gem_name}[\w\/]+["'])/, "\\1#{require_target}/\\2")
+      process_files(/require (["'])#{Regexp.escape require_entrypoint}/, "require \\1#{require_target}/#{require_entrypoint}")
+      process_files(/(autoload\s+[:\w]+,\s+["'])(#{Regexp.escape require_entrypoint}[\w\/]+["'])/, "\\1#{require_target}/\\2")
     end
 
     def clean


### PR DESCRIPTION
When gems extend the functionality of another gem, they usually use dashes for naming and including their functionality under the namespace of the extended gem.

This is explained at https://guides.rubygems.org/name-your-gem/.

With these changes, those gems are also properly vendored by default.