### PR TITLE
Use a better module substitution regexp

### DIFF
--- a/lib/automatiek/gem.rb
+++ b/lib/automatiek/gem.rb
@@ -62,7 +62,7 @@ module Automatiek
     def namespace_files(folder)
       files = Dir.glob("#{folder}/**/*.rb")
       require_target = vendor_lib.sub(%r{^(.+?/)?lib/}, "") << "/lib"
-      process(files, namespace, "#{prefix}::#{namespace}")
+      process(files, /\b#{namespace}\b/, "#{prefix}::#{namespace}")
       process(files, /require (["'])#{Regexp.escape require_entrypoint}/, "require \\1#{require_target}/#{require_entrypoint}")
       process(files, /(autoload\s+[:\w]+,\s+["'])(#{Regexp.escape require_entrypoint}[\w\/]+["'])/, "\\1#{require_target}/\\2")
     end


### PR DESCRIPTION
When vendoring the `uri` gem with the following configuration

```ruby
desc "Vendor a specific version of uri"
Automatiek::RakeTask.new("uri") do |lib|
  lib.download = { :github => "https://github.com/ruby/uri" }
  lib.namespace = "URI"
  lib.prefix = "Bundler"
  lib.vendor_lib = "lib/bundler/vendor/uri"
end
```

I got some false positives preventing the vendored library to work. For example `URI::BadURIError` getting replaced by `Bundler::URI::BadBundler::URIError`.

This commit should fix that.